### PR TITLE
Feat: add dark and light mode for website

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,18 +2,14 @@ import React, { useEffect, useState } from 'react';
 import logo from '@/assets/images/logo.png';
 import { Link, useNavigate } from 'react-router-dom';
 import courses from '@/data/courseData';
+import { useTheme } from '@/context/ThemeContext';
+
 
 function Navbar({ loggedin }) {
   const [searchTerm, setSearchTerm] = useState('');
   const [suggestions, setSuggestions] = useState([]);
-  const [theme, setTheme] = useState('light');
+  const { theme, toggleTheme } = useTheme();
   const navigate = useNavigate();
-
-  const toggleTheme = () => {
-    const newTheme = theme === 'light' ? 'dark' : 'light';
-    setTheme(newTheme);
-    document.body.setAttribute('data-bs-theme', newTheme)
-  };
 
   const handleSearchChange = (event) => {
     const searchInput = event.target.value;
@@ -44,11 +40,6 @@ function Navbar({ loggedin }) {
     navigate(`/search?query=${encodeURIComponent(suggestion.title)}`);
     setSuggestions([]);
   };
-
-  useEffect(() => {
-    document.body.setAttribute('data-bs-theme', theme);
-  }, []);
-
 
   return (
     <nav className={`navbar navbar-expand-lg sticky-top bg-body-tertiary navbar-${theme}`}>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import logo from '@/assets/images/logo.png';
 import { Link, useNavigate } from 'react-router-dom';
 import courses from '@/data/courseData';
@@ -6,7 +6,14 @@ import courses from '@/data/courseData';
 function Navbar({ loggedin }) {
   const [searchTerm, setSearchTerm] = useState('');
   const [suggestions, setSuggestions] = useState([]);
+  const [theme, setTheme] = useState('light');
   const navigate = useNavigate();
+
+  const toggleTheme = () => {
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+    document.body.setAttribute('data-bs-theme', newTheme)
+  };
 
   const handleSearchChange = (event) => {
     const searchInput = event.target.value;
@@ -38,8 +45,13 @@ function Navbar({ loggedin }) {
     setSuggestions([]);
   };
 
+  useEffect(() => {
+    document.body.setAttribute('data-bs-theme', theme);
+  }, []);
+
+
   return (
-    <nav className="navbar navbar-expand-lg sticky-top bg-body-tertiary">
+    <nav className={`navbar navbar-expand-lg sticky-top bg-body-tertiary navbar-${theme}`}>
       <div className="container-fluid">
         <button
           className="navbar-toggler"
@@ -114,6 +126,20 @@ function Navbar({ loggedin }) {
 
           {loggedin === 'true' ? (
             <div className="d-flex align-items-center flex-column flex-lg-row">
+              <span className="me-3">
+                <button
+                  className="btn clk rounded-circle"
+                  onClick={toggleTheme}
+                  data-bs-toggle="tooltip"
+                  title={`Switch to ${theme === 'light' ? 'Dark' : 'Light'} Mode`}
+                >
+                  {theme === 'light' ? (
+                    <i className="fa-solid fa-moon"></i>
+                  ) : (
+                    <i className="fa-solid fa-sun"></i>
+                  )}
+                </button>
+              </span>
               <div className="me-2 mb-2 mb-lg-0 position-relative">
                 <form className="input-group" onSubmit={handleSearchSubmit}>
                   <span className="input-group-text" id="basic-addon1">

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -123,23 +123,23 @@ function Navbar({ loggedin }) {
               </ul>
             </li>
           </ul>
-
+          <span className="me-3">
+            <button
+              className="btn clk rounded-circle"
+              onClick={toggleTheme}
+              data-bs-toggle="tooltip"
+              title={`Switch to ${theme === 'light' ? 'Dark' : 'Light'} Mode`}
+            >
+              {theme === 'light' ? (
+                <i className="fa-solid fa-moon"></i>
+              ) : (
+                <i className="fa-solid fa-sun"></i>
+              )}
+            </button>
+          </span>
           {loggedin === 'true' ? (
             <div className="d-flex align-items-center flex-column flex-lg-row">
-              <span className="me-3">
-                <button
-                  className="btn clk rounded-circle"
-                  onClick={toggleTheme}
-                  data-bs-toggle="tooltip"
-                  title={`Switch to ${theme === 'light' ? 'Dark' : 'Light'} Mode`}
-                >
-                  {theme === 'light' ? (
-                    <i className="fa-solid fa-moon"></i>
-                  ) : (
-                    <i className="fa-solid fa-sun"></i>
-                  )}
-                </button>
-              </span>
+
               <div className="me-2 mb-2 mb-lg-0 position-relative">
                 <form className="input-group" onSubmit={handleSearchSubmit}>
                   <span className="input-group-text" id="basic-addon1">

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -6,7 +6,9 @@ export const ThemeProvider = ({ children }) => {
   const [theme, setTheme] = useState('light');
 
   const toggleTheme = () => {
-    setTheme((prevTheme) => (prevTheme === 'light' ? 'dark' : 'light'));
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+    document.body.setAttribute('data-bs-theme', newTheme);
   };
 
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,9 +4,12 @@ import App from './App.jsx';
 import './styles/index.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
+import { ThemeProvider } from './context/ThemeContext.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>
 );

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -7,3 +7,13 @@
   justify-content: center;
   align-items: center;
 }
+
+[data-bs-theme="dark"] {
+  --bs-body-color: #f8f9fa;
+  --bs-body-bg: #212529;
+}
+
+[data-bs-theme="light"] {
+  --bs-body-color: #212529;
+  --bs-body-bg: #f8f9fa;
+}


### PR DESCRIPTION
# Dark and Light Mode Implementation

## Description
This PR introduces a dark and light mode toggle feature for the CourseKrimson website, enhancing user experience by allowing them to switch between color schemes based on their preference or environment.

## Changes
- Added theme state and toggle functionality in `Navbar.jsx`
- Implemented a theme toggle button in the navigation bar
- Updated navbar classes to reflect the current theme
- Added theme-specific CSS variables in `index.css` for consistent styling across the site

## How to Test
1. Clone the branch and run the project locally
2. Navigate to any page with the navbar visible
3. Look for the new theme toggle button (moon/sun icon)
4. Click the button to switch between dark and light modes
5. Verify that the color scheme changes appropriately throughout the site

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/e1aa1cc8-89e2-4e63-b6e9-bef98617fae6)

### After
![image](https://github.com/user-attachments/assets/5bc02e71-637d-4818-a235-24256a95dfbb)


## Additional Notes
- This feature uses Bootstrap's theming system and custom CSS variables for seamless integration
- The chosen theme persists across page navigation but resets on page reload (consider adding local storage persistence in a future update)

Closes #7 